### PR TITLE
Feature update dependencies

### DIFF
--- a/sqskiq.gemspec
+++ b/sqskiq.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.homepage    = 'https://github.com/ricardolazaro/sqskiq'
 
-  s.add_dependency "celluloid", "~> 0.14.1"
+  s.add_dependency "celluloid", "~> 0.15"
   s.add_dependency "aws-sdk", "~> 1.9.1"
   s.add_dependency "activesupport"
   s.add_development_dependency "rspec"

--- a/sqskiq.gemspec
+++ b/sqskiq.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/ricardolazaro/sqskiq'
 
   s.add_dependency "celluloid", "~> 0.15"
-  s.add_dependency "aws-sdk", "~> 1.9.1"
+  s.add_dependency "aws-sdk", "~> 1"
   s.add_dependency "activesupport"
   s.add_development_dependency "rspec"
 end


### PR DESCRIPTION
updates celluloid and aws-sdk version specifiers.  Also loosens restrictions to allow minor release updates for ease of integration with other gems which may want similar gems.

@fatum your PR's did similar but I did not want to introduce other code changes just so we can get updated gem dependencies
